### PR TITLE
Fix async jest

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,4 +79,10 @@ export default class CLI {
     launch(): void {
         console.log(`(${this.spacecraft.x}, ${this.spacecraft.y}) spacecraft launched from Earth`);
     }
+
+    exit(): void {
+        console.log("Closing! Goodbye.");
+
+        this.input.destroy()
+    }
 }

--- a/tests/spacecraft.spec.ts
+++ b/tests/spacecraft.spec.ts
@@ -21,6 +21,12 @@ describe('Spacecraft', () => {
     const cli = new CLI(process.stdin, process.stdout, spacecraft);
     cli.start();
 
+    afterAll(() => {
+        // Finalize the inputStream
+
+        cli.exit();
+    });
+
     it('starts from Earth', () => {
         expect(spacecraft.x).toBe(Earth.x);
         expect(spacecraft.y).toBe(Earth.y);
@@ -57,8 +63,8 @@ describe('Spacecraft', () => {
     });
 
     it('accelerates correctly', () => {
-        // (0, 5) => (0, 7) => (0, 10) => (0, 14) => (0, 19) 
-        
+        // (0, 5) => (0, 7) => (0, 10) => (0, 14) => (0, 19)
+
         spacecraft.moveForward(1);
         expect(spacecraft.x).toBe(0);
         expect(spacecraft.y).toBe(7);
@@ -76,4 +82,3 @@ describe('Spacecraft', () => {
         expect(spacecraft.y).toBe(19);
     });
 });
-


### PR DESCRIPTION
**CHANGELOG** :memo:

* Add method to destroy the inputStream
* Add `afterAll` jest hook to destroy inputStream after tests run.

**PRINTS(OPTIONAL)** :framed_picture:

:no_entry: 

**LABELS**

* enhancement
